### PR TITLE
Enable GitHub Actions bot to push to main

### DIFF
--- a/.github/workflows/publish_rebabel.yml
+++ b/.github/workflows/publish_rebabel.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: main
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: actions/setup-node@master
         with:
           node-version: "latest"

--- a/.github/workflows/publish_rebabel.yml
+++ b/.github/workflows/publish_rebabel.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "package.json"
+      - "package-lock.json"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
@ElizabethThorner The following steps are required to enable the GitHub Actions bot to push to main:

-  Create a Deploy Key
![Screen Shot 2024-11-10 at 8 42 20 AM](https://github.com/user-attachments/assets/ba32a28d-c911-4e1e-ba55-9dfc1fdc50dc)

- Create a public-private ssh key pair: `ssh-keygen -t rsa -b 4096 -C "41898282+github-actions[bot]@users.noreply.github.com"`
- Add the generated public key to the deploy key contents and check **Allow write access**
![Screen Shot 2024-11-10 at 8 50 42 AM](https://github.com/user-attachments/assets/5774bb65-8a99-43d1-a8c3-a2182d577a33)
- Add a secret with a value of the private key
![Screen Shot 2024-11-10 at 8 45 25 AM](https://github.com/user-attachments/assets/7701a2cd-f710-4b50-9738-6892bedb1d18)
- Make sure the name of the secret is **DEPLOY_KEY**
![Screen Shot 2024-11-10 at 8 46 30 AM](https://github.com/user-attachments/assets/a124d3bb-fe56-4eda-91eb-e90d1a430490)
