### PR TITLE
Adds help icon and opens the help window

### DIFF
--- a/src/Components/App.jsx
+++ b/src/Components/App.jsx
@@ -33,7 +33,7 @@ function App() {
     message: "An Unexpected Error Occured!",
   });
   //Set state for modals
-  const [isMappingsOpen, setMappingsOpen] = useState(false);
+  const [isMappingsOpen, setMappingsOpen] = useState(true);
   const [isInputFileConfigOpen, setInputFileConfigOpen] = useState(false);
   const [isOutputFileConfigOpen, setOutputFileConfigOpen] = useState(false);
   const [isDisplayResultsOpen, setDisplayResultsOpen] = useState(false);

--- a/src/Components/App.jsx
+++ b/src/Components/App.jsx
@@ -33,7 +33,7 @@ function App() {
     message: "An Unexpected Error Occured!",
   });
   //Set state for modals
-  const [isMappingsOpen, setMappingsOpen] = useState(true);
+  const [isMappingsOpen, setMappingsOpen] = useState(false);
   const [isInputFileConfigOpen, setInputFileConfigOpen] = useState(false);
   const [isOutputFileConfigOpen, setOutputFileConfigOpen] = useState(false);
   const [isDisplayResultsOpen, setDisplayResultsOpen] = useState(false);

--- a/src/Components/Mappings/Mappings.jsx
+++ b/src/Components/Mappings/Mappings.jsx
@@ -196,7 +196,10 @@ function Mappings({ isOpen, onClose, data, setData, errors, setErrorState }) {
       <article>
         <h2>Mappings</h2>
         <a data-tooltip="Open Mappings Help" data-placement="right">
-          <MdOutlineHelp className={styles.helpIcon} />
+          <MdOutlineHelp
+            className={styles.helpIcon}
+            onClick={() => window.pythonApi.openHelpWindow()}
+          />
         </a>
         <hr></hr>
         <section>

--- a/src/Components/Mappings/Mappings.jsx
+++ b/src/Components/Mappings/Mappings.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Error from "../Error.jsx";
 import styles from "./Mappings.module.css";
 import MappingsTable from "./MappingsTable.jsx";
+import { MdOutlineHelp } from "react-icons/md";
 
 function Mappings({ isOpen, onClose, data, setData, errors, setErrorState }) {
   const [isAddTypeMappingOpen, setAddTypeMappingOpen] = useState(false);
@@ -194,6 +195,9 @@ function Mappings({ isOpen, onClose, data, setData, errors, setErrorState }) {
     <dialog open={isOpen} className="modal-overlay">
       <article>
         <h2>Mappings</h2>
+        <a data-tooltip="Open Mappings Help" data-placement="right">
+          <MdOutlineHelp className={styles.helpIcon} />
+        </a>
         <hr></hr>
         <section>
           {errors.mappings.status && (

--- a/src/Components/Mappings/Mappings.module.css
+++ b/src/Components/Mappings/Mappings.module.css
@@ -14,6 +14,22 @@
   margin-left: 0.5rem;
 }
 
+h2 {
+  display: contents;
+}
+
+a {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.helpIcon {
+  margin-left: 0.5rem;
+  margin-bottom: 0.4rem;
+  font-size: 1.2rem;
+  color: #2c5d8a;
+}
+
 .inputsContainer {
   display: flex;
   flex-direction: row;

--- a/src/Components/OutputConfigs/OutputFileConfig.jsx
+++ b/src/Components/OutputConfigs/OutputFileConfig.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import FlextextConfig from "./FlextextConfig.jsx";
 import ElanConfig from "./ElanConfig.jsx";
+import styles from "./OutputFileConfig.module.css";
+import { MdOutlineHelp } from "react-icons/md";
 
 function OutputFileConfig({
   isOpen,
@@ -12,25 +14,35 @@ function OutputFileConfig({
   includedLayerValues,
   setIncludedLayerValues,
   elanTemplateFileName,
-  setElanTemplateFileName
+  setElanTemplateFileName,
 }) {
+  //help info tooltip display text
+  let helpTextInfo = "";
 
   function getDialogConfigTitle() {
     let dialogConfigTitle = "";
 
     if (data.outFileType === "flextext") {
       dialogConfigTitle = "Flextext";
+      helpTextInfo = "Open Flextext Settings Help";
     } else if (data.outFileType === "elan") {
       dialogConfigTitle = "ELAN";
+      helpTextInfo = "Open Elan Settings Help";
     }
 
     return dialogConfigTitle;
   }
-  
+
   return (
     <dialog open={isOpen} className="modal-overlay">
       <article>
-        <h2>{getDialogConfigTitle()} Configuration Settings</h2>
+        <h2>{getDialogConfigTitle()} Configuration Settings</h2>{" "}
+        <a data-tooltip={helpTextInfo} data-placement="bottom">
+          <MdOutlineHelp
+            className={styles.helpIcon}
+            onClick={() => window.pythonApi.openHelpWindow()}
+          />
+        </a>
         <hr></hr>
         <section>
           {data.outFileType === "flextext" && (

--- a/src/Components/OutputConfigs/OutputFileConfig.module.css
+++ b/src/Components/OutputConfigs/OutputFileConfig.module.css
@@ -8,7 +8,7 @@ a {
 }
 
 .helpIcon {
-  margin-left: 0.5rem;
+  margin-left: 0.3rem;
   margin-bottom: 0.4rem;
   font-size: 1.2rem;
   color: #2c5d8a;

--- a/src/Components/OutputConfigs/OutputFileConfig.module.css
+++ b/src/Components/OutputConfigs/OutputFileConfig.module.css
@@ -1,0 +1,15 @@
+h2 {
+  display: contents;
+}
+
+a {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.helpIcon {
+  margin-left: 0.5rem;
+  margin-bottom: 0.4rem;
+  font-size: 1.2rem;
+  color: #2c5d8a;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const FileExtensions = {
   elan: ".eaf",
   nlp_pos: ".txt",
 };
+let helpOpen = false;
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require("electron-squirrel-startup")) {
@@ -42,6 +43,10 @@ const createHelpWindow = () => {
 
   mainWindow.loadFile(filePath);
   mainWindow.setMenu(null);
+
+  mainWindow.on("close", () => {
+    helpOpen = !helpOpen;
+  });
 };
 
 const createWindow = () => {
@@ -193,7 +198,10 @@ app.whenReady().then(() => {
   });
 
   ipcMain.on("openHelpWindow", () => {
-    createHelpWindow();
+    if (!helpOpen) {
+      createHelpWindow();
+      helpOpen = true;
+    }
   });
 
   // On OS X it's common to re-create a window in the app when the
@@ -263,7 +271,10 @@ function insertHelpWindow(menuTemplate) {
         //Help entry in Help drop down
         if (menuTemplate[item].submenu[index].label === "Help") {
           menuTemplate[item].submenu[index].click = () => {
-            createHelpWindow();
+            if (!helpOpen) {
+              createHelpWindow();
+              helpOpen = true;
+            }
           };
         }
       }

--- a/src/main.js
+++ b/src/main.js
@@ -192,6 +192,10 @@ app.whenReady().then(() => {
     return returnData;
   });
 
+  ipcMain.on("openHelpWindow", () => {
+    createHelpWindow();
+  });
+
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   app.on("activate", () => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,6 +1,8 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("pythonApi", {
-  getFile: (isMainFileSelect) => ipcRenderer.invoke("selectFile", isMainFileSelect),
-  rebabelConvert: (data) => ipcRenderer.invoke("rebabelConvert", data)
+  getFile: (isMainFileSelect) =>
+    ipcRenderer.invoke("selectFile", isMainFileSelect),
+  rebabelConvert: (data) => ipcRenderer.invoke("rebabelConvert", data),
+  openHelpWindow: () => ipcRenderer.send("openHelpWindow"),
 });


### PR DESCRIPTION
Added help icons to the mappings, and output file config components so they show up and trigger the help documentation when clicked. Also adjusted the help window so only a single instance can be opened.