### PR TITLE
Update Help Menu Styling

### DIFF
--- a/src/HelpDocumentation/Help/index.html
+++ b/src/HelpDocumentation/Help/index.html
@@ -28,17 +28,17 @@
           <li>
             <a href="importing.html">Importing</a>
             <ul>
-              <a href="importing.html#nlp"><li>NLP Settings</li></a>
+              <li><a href="importing.html#nlp">NLP Settings</a></li>
             </ul>
           </li>
           <li>
             <a href="exporting.html">Exporting</a>
             <ul>
-              <a href="exporting.html#flextext"><li>Flextext Settings</li></a>
-              <a href="exporting.html#elan"><li>ELAN Settings</li></a>
+              <li><a href="exporting.html#flextext">Flextext Settings</a></li>
+              <li><a href="exporting.html#elan">ELAN Settings</a></li>
             </ul>
           </li>
-          <a href="mappings.html"><li>Mappings</li></a>
+          <li><a href="mappings.html">Mappings</a></li>
         </ul>
       </section>
     </main>

--- a/src/HelpDocumentation/helpDocumentation.css
+++ b/src/HelpDocumentation/helpDocumentation.css
@@ -18,7 +18,16 @@ a {
 }
 
 a:hover {
-  font-weight: 500;
+  text-decoration: underline;
+}
+
+li > ul {
+  margin-bottom: 0rem;
+  margin-top: 0.2rem;
+}
+
+li {
+  padding: 0rem;
 }
 
 table {


### PR DESCRIPTION
Changed the links to be underlined on hover instead of bold because there was some distortion with the font weight. Also the spacing for the menu was modified and I fixed the links to be inside the li element.